### PR TITLE
Small fixes for air60 v2

### DIFF
--- a/keyboards/nuphy/air60_v2/ansi/rgb.c
+++ b/keyboards/nuphy/air60_v2/ansi/rgb.c
@@ -501,7 +501,22 @@ void rf_led_show(void) {
 
     // light up corresponding BT/RF key
     if (dev_info.link_mode <= LINK_BT_3) {
-        uint8_t my_pos = dev_info.link_mode == LINK_RF_24 ? 23 : (19 + dev_info.link_mode);
+        uint8_t my_pos;
+        switch (dev_info.link_mode)
+        {
+            case LINK_BT_1:
+                my_pos = LED_BT_1;
+                break;
+            case LINK_BT_2:
+                my_pos = LED_BT_2;
+                break;
+            case LINK_BT_3:
+                my_pos = LED_BT_3;
+                break;
+            default:
+                my_pos = LED_RF_24;
+                break;
+        }
         rgb_required = 1;
         rgb_matrix_set_color(my_pos, current_rgb.r, current_rgb.g, current_rgb.b);
     }
@@ -533,7 +548,7 @@ void bat_num_led(void) {
     if (bat_percent % 10 == 0) { bat_pct--; }
 
     for(uint8_t i=0; i < bat_pct; i++) {
-        rgb_matrix_set_color(20 + i, r, g, b);
+        rgb_matrix_set_color(1 + i, r, g, b);
     }
     // set percent
 
@@ -547,7 +562,7 @@ void bat_num_led(void) {
         r = 0x00; g = 0xff; b = 0x00;
     }
 
-    rgb_matrix_set_color(20 + bat_pct, r, g, b);
+    rgb_matrix_set_color(1 + bat_pct, r, g, b);
 
 }
 

--- a/keyboards/nuphy/air60_v2/ansi/user_kb.c
+++ b/keyboards/nuphy/air60_v2/ansi/user_kb.c
@@ -259,18 +259,18 @@ void dial_set(uint8_t dial_scan, bool led_sys_show) {
     }
 
     if (dial_scan & 0x02) {
-        if (dev_info.sys_sw_state != SYS_SW_MAC) {
-            if (led_sys_show) { sys_show_timer = timer_read32(); }
-            default_layer_set(1 << 0);
-            dev_info.sys_sw_state = SYS_SW_MAC;
-            keymap_config.nkro    = 0;
-        }
-    } else {
         if (dev_info.sys_sw_state != SYS_SW_WIN) {
             if (led_sys_show) { sys_show_timer = timer_read32(); }
-            default_layer_set(1 << 3);
+            default_layer_set(1 << WIN_BASE_LAYER_NUM);
             dev_info.sys_sw_state = SYS_SW_WIN;
             keymap_config.nkro    = 1;
+        }
+    } else {
+        if (dev_info.sys_sw_state != SYS_SW_MAC) {
+            if (led_sys_show) { sys_show_timer = timer_read32(); }
+            default_layer_set(1 << MAC_BASE_LAYER_NUM);
+            dev_info.sys_sw_state = SYS_SW_MAC;
+            keymap_config.nkro    = 0;
         }
     }
 }

--- a/keyboards/nuphy/air60_v2/ansi/user_kb.h
+++ b/keyboards/nuphy/air60_v2/ansi/user_kb.h
@@ -86,6 +86,11 @@ typedef enum {
 #define LINK_BT_3                 3
 #define LINK_USB                  4
 
+#define LED_RF_24                18
+#define LED_BT_1                 15
+#define LED_BT_2                 16
+#define LED_BT_3                 17
+
 #define UART_HEAD                 0x5A
 #define FUNC_VALID_LEN            32
 #define UART_MAX_LEN              64
@@ -110,6 +115,9 @@ typedef enum {
 
 #define RGB_MATRIX_GAME_MODE      RGB_MATRIX_GRADIENT_LEFT_RIGHT
 #define SIDE_MATRIX_GAME_MODE     4
+
+#define    MAC_BASE_LAYER_NUM     0
+#define    WIN_BASE_LAYER_NUM     3
 
 #define    CAPS_LED               28
 #define    LSHIFT_LED             41


### PR DESCRIPTION
# Added small fixes to Air60 V2 :
- RGB fixed for BT and RF switch
- WIN / MAC switch was mirrored in code, fixed
- Battery number display RGB layout

Also tested the sleep function and the keyboard as a whole: I did not find any problems during operation. Slép works as intended, RGB is flawless (as far as I can tell).