### PR TITLE
Use LNK_RF instead of a constant offset of the link mode keycodes

### DIFF
--- a/keyboards/nuphy/air60_v2/ansi/ansi.c
+++ b/keyboards/nuphy/air60_v2/ansi/ansi.c
@@ -171,7 +171,7 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
         case LNK_RF ... LNK_BLE3:
             if (record->event.pressed) {
                 if (dev_info.link_mode != LINK_USB) {
-                    rf_sw_temp    = keycode - 2;
+                    rf_sw_temp    = keycode - LNK_RF;
                     f_rf_sw_press = 1;
                     break_all_key();
                 }

--- a/keyboards/nuphy/air75_v2/ansi/ansi.c
+++ b/keyboards/nuphy/air75_v2/ansi/ansi.c
@@ -170,7 +170,7 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
         case LNK_RF ... LNK_BLE3:
             if (record->event.pressed) {
                 if (dev_info.link_mode != LINK_USB) {
-                    rf_sw_temp    = keycode - 2;
+                    rf_sw_temp    = keycode - LNK_RF;
                     f_rf_sw_press = 1;
                     break_all_key();
                 }

--- a/keyboards/nuphy/air96_v2/ansi/ansi.c
+++ b/keyboards/nuphy/air96_v2/ansi/ansi.c
@@ -171,7 +171,7 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
         case LNK_RF ... LNK_BLE3:
             if (record->event.pressed) {
                 if (dev_info.link_mode != LINK_USB) {
-                    rf_sw_temp    = keycode - 2;
+                    rf_sw_temp    = keycode - LNK_RF;
                     f_rf_sw_press = 1;
                     break_all_key();
                 }


### PR DESCRIPTION
I was adding a custom keycode at the very top of the keycodes in ansi.h. But it accidentally broke the wireless connections. Then I found in the code where the `link_mode` uses a hardcoded offset.

This change will prevent unexpected changes in the behaviour of the keys for wireless connections.